### PR TITLE
added permissions

### DIFF
--- a/api_server.go
+++ b/api_server.go
@@ -401,6 +401,17 @@ func handleInsertHost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Convert permissions array to string if not empty
+	if len(data.Permissions) > 0 {
+		permissionsJSON, err := json.Marshal(data.Permissions)
+		if err != nil {
+			http.Error(w, "Failed to process permissions", http.StatusBadRequest)
+			log.Error().Err(err).Msg("Failed to marshal permissions")
+			return
+		}
+		data.PermissionsString = string(permissionsJSON)
+	}
+
 	pattern := `^bafy[a-zA-Z0-9]{50,}$`
 	matched, err := regexp.MatchString(pattern, data.Destination)
 	if err != nil || !matched {
@@ -484,6 +495,17 @@ func handleUpdateHost(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Destination and UpdaterID are required", http.StatusBadRequest)
 		log.Error().Msg("Destination and UpdaterID are required")
 		return
+	}
+
+	// Convert permissions array to string if not empty
+	if len(data.Permissions) > 0 {
+		permissionsJSON, err := json.Marshal(data.Permissions)
+		if err != nil {
+			http.Error(w, "Failed to process permissions", http.StatusBadRequest)
+			log.Error().Err(err).Msg("Failed to marshal permissions")
+			return
+		}
+		data.PermissionsString = string(permissionsJSON)
 	}
 
 	pattern := `^bafy[a-zA-Z0-9]{50,}$`

--- a/api_server.go
+++ b/api_server.go
@@ -401,16 +401,14 @@ func handleInsertHost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Convert permissions array to string if not empty
-	if len(data.Permissions) > 0 {
-		permissionsJSON, err := json.Marshal(data.Permissions)
-		if err != nil {
-			http.Error(w, "Failed to process permissions", http.StatusBadRequest)
-			log.Error().Err(err).Msg("Failed to marshal permissions")
-			return
-		}
-		data.PermissionsString = string(permissionsJSON)
+	// Always set PermissionsString regardless of array length
+	permissionsJSON, err := json.Marshal(data.Permissions)
+	if err != nil {
+		http.Error(w, "Failed to process permissions", http.StatusBadRequest)
+		log.Error().Err(err).Msg("Failed to marshal permissions")
+		return
 	}
+	data.PermissionsString = string(permissionsJSON)
 
 	pattern := `^bafy[a-zA-Z0-9]{50,}$`
 	matched, err := regexp.MatchString(pattern, data.Destination)
@@ -497,16 +495,14 @@ func handleUpdateHost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Convert permissions array to string if not empty
-	if len(data.Permissions) > 0 {
-		permissionsJSON, err := json.Marshal(data.Permissions)
-		if err != nil {
-			http.Error(w, "Failed to process permissions", http.StatusBadRequest)
-			log.Error().Err(err).Msg("Failed to marshal permissions")
-			return
-		}
-		data.PermissionsString = string(permissionsJSON)
+	// Always set PermissionsString regardless of array length
+	permissionsJSON, err := json.Marshal(data.Permissions)
+	if err != nil {
+		http.Error(w, "Failed to process permissions", http.StatusBadRequest)
+		log.Error().Err(err).Msg("Failed to marshal permissions")
+		return
 	}
+	data.PermissionsString = string(permissionsJSON)
 
 	pattern := `^bafy[a-zA-Z0-9]{50,}$`
 	matched, err := regexp.MatchString(pattern, data.Destination)

--- a/migrations/2_add_permissions.go
+++ b/migrations/2_add_permissions.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"database/sql"
+	"log"
+	"os"
+
+	"github.com/joho/godotenv"
+	_ "github.com/lib/pq"
+)
+
+func main() {
+	_ = godotenv.Load() // Ignore error if .env file is not present
+
+	connStr := os.Getenv("POSTGRES_CONN")
+	if connStr == "" {
+		log.Fatal("POSTGRES_CONN environment variable is required")
+	}
+
+	db, err := sql.Open("postgres", connStr)
+	if err != nil {
+		log.Fatal("Failed to connect to database:", err)
+	}
+	defer db.Close()
+
+	// Add permissions column to the hosts table
+	_, err = db.Exec("ALTER TABLE hosts ADD COLUMN IF NOT EXISTS permissions JSONB DEFAULT '[]'::jsonb")
+	if err != nil {
+		log.Fatal("Failed to add permissions column:", err)
+	}
+
+	log.Println("Added permissions column to hosts table successfully")
+}

--- a/types.go
+++ b/types.go
@@ -3,12 +3,14 @@ package main
 import "time"
 
 type HostData struct {
-	Host        string    `json:"host"`
-	Destination string    `json:"destination"`
-	Owner       string    `json:"owner"`
-	Created     time.Time `json:"created"`
-	Updated     time.Time `json:"updated"`
-	UpdaterID   string    `json:"updater_id,omitempty"`
-	EntryMethod string    `json:"entry_method"`          // New field
-	ReturnType  string    `json:"return_type,omitempty"` // New field
+	Host              string    `json:"host"`
+	Destination       string    `json:"destination"`
+	Owner             string    `json:"owner"`
+	Created           time.Time `json:"created"`
+	Updated           time.Time `json:"updated"`
+	UpdaterID         string    `json:"updater_id"`
+	EntryMethod       string    `json:"entry_method"`
+	ReturnType        string    `json:"return_type"`
+	Permissions       []string  `json:"permissions"` // Array of permission strings
+	PermissionsString string    `json:"-"`           // Storage format for database (not exposed in JSON)
 }


### PR DESCRIPTION
This pull request includes several changes to manage permissions for hosts in the system. The changes introduce a new `permissions_string` field to store permissions as a JSON string in the database, and update various functions to handle this new field.

### Database schema updates:
* Added a new column `permissions_string` to the `hosts` table, with a default value of an empty array.
* Updated the database initialization and migration scripts to ensure the new `permissions_string` column is created if it does not exist. [[1]](diffhunk://#diff-ac94c91f8ea84762d55b6932ef1466a2165984591d3e646360c5bb31b2130900L40-R80) [[2]](diffhunk://#diff-1efdc2fc7cee821ed8f71ac7e269f295bbb13011e48e893c82830feabe7f8608R1-R33)

### API handler updates:
* Updated `handleInsertHost` and `handleUpdateHost` functions to convert the `Permissions` array to a JSON string and store it in the `permissions_string` field. [[1]](diffhunk://#diff-956e1a98a85636e280f11acb02f330467cc70374b9183ccc5502e45650d262c4R404-R414) [[2]](diffhunk://#diff-956e1a98a85636e280f11acb02f330467cc70374b9183ccc5502e45650d262c4R500-R510)

### Data handling updates:
* Modified the `HostData` struct to include `Permissions` and `PermissionsString` fields, where `Permissions` is an array of strings and `PermissionsString` is the storage format for the database.
* Updated database query functions to include the `permissions_string` field in the SELECT statements and scan the results into the `HostData` struct.